### PR TITLE
Added method to use google account to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ $ go install github.com/tenntenn/calcon/cmd/calcon@latest
 
 ## How to use
 
+### Use Google Account
+
+```
+# Output to ics files
+$ gcloud auth application-default login --scopes openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/calendar.events.readonly
+$ calcon -output ics -format ics <Google Calendar ID>
+
+# Output to Google calndear links(CSV)
+$ gcloud auth application-default login --scopes openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/calendar.events.readonly
+$ calcon -output calendar.csv -format google-csv <Google Calendar ID>
+
+# Output to Google calndear links(JSON)
+$ gcloud auth application-default login --scopes openid,https://www.googleapis.com/auth/userinfo.email,https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/calendar.events.readonly
+$ calcon -output calendar.json -format google-json <Google Calendar ID>
+
+```
+
+### Use Service Account
+
 ```
 # Output to ics files
 $ export GOOGLE_APPLICATION_CREDENTIAL=<path to credential file> 


### PR DESCRIPTION
When running locally, it's easier and more secure to use your own Google Account, which uses a Service Account.